### PR TITLE
configuração de banco de dados mysql

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/stock_flex_db?createDatabaseIfNotExist=true&serverTimezone=UTC&useSSL=false
+    username: root
+    password: P@ssw0rd
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
+  output:
+    ansi:
+      enabled: ALWAYS


### PR DESCRIPTION
## Atualização da Configuração do Banco de Dados

### URL do Banco de Dados:
- URL para jdbc:mysql://localhost:3306/stock_flex.
- Credenciais de Acesso: Definição de usuário como root e senha segura.
- Fuso Horário e SSL: Configuração para UTC e desativação do uso de SSL.
- Criação Automática de Tabelas: Ativação da criação automática de tabelas pelo Hibernate.
- Exibição de Consultas SQL: Habilitação da exibição de consultas SQL geradas.
- Formatação SQL: Ativação da formatação legível das consultas SQL.

## Recursos Úteis

[Entendendo database](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql)
