### PR TITLE
Mapeamento de classes

### DIFF
--- a/src/main/java/com/stock/flex/entity/CategoryEntity.java
+++ b/src/main/java/com/stock/flex/entity/CategoryEntity.java
@@ -3,18 +3,16 @@ package com.stock.flex.entity;
 
 import com.stock.flex.resource.request.CategoryRequest;
 
+import com.stock.flex.resource.request.ProductRequest;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.GenerationType;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -29,23 +27,35 @@ public class CategoryEntity {
     private UUID id;
     private String name;
     private String description;
-    private List<String> products;
+
+    @ManyToOne // Mapeamento muitos-para-um com StockEntity
+    @JoinColumn(name = "stock_id") // Nome da coluna de junção
+    private StockEntity stock;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "category") // Mapeamento um-para-muitos com ProductEntity
+    private List<ProductEntity> products;
 
     public CategoryEntity(CategoryRequest request) {
         this.name = request.name();
         this.description = request.description();
-        this.products = request.products();
+        this.products =  mapProductRequestsToEntities(request.products());
     }
 
-    public void updateInfo(CategoryRequest response) {
-        if (response.name() != null) {
-            this.name = response.name();
+    public void updateInfo(CategoryRequest request) {
+        if (request.name() != null) {
+            this.name = request.name();
         }
-        if (response.description() != null) {
-            this.description = response.description();
+        if (request.description() != null) {
+            this.description = request.description();
         }
-        if (response.products() != null) {
-            this.products = response.products();
-        }
+        this.products = mapProductRequestsToEntities(request.products());
     }
-}
+
+    private List<ProductEntity> mapProductRequestsToEntities(List<ProductRequest> productRequests) {
+        return productRequests.stream()
+                .map(ProductEntity::new) // Criar ProductEntity a partir do ProductRequest
+                .collect(Collectors.toList());
+    }
+
+    }
+

--- a/src/main/java/com/stock/flex/entity/CategoryEntity.java
+++ b/src/main/java/com/stock/flex/entity/CategoryEntity.java
@@ -2,7 +2,6 @@ package com.stock.flex.entity;
 
 
 import com.stock.flex.resource.request.CategoryRequest;
-
 import com.stock.flex.resource.request.ProductRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -28,17 +27,17 @@ public class CategoryEntity {
     private String name;
     private String description;
 
-    @ManyToOne // Mapeamento muitos-para-um com StockEntity
-    @JoinColumn(name = "stock_id") // Nome da coluna de junção
+    @ManyToOne
+    @JoinColumn(name = "stock_id")
     private StockEntity stock;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "category") // Mapeamento um-para-muitos com ProductEntity
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "category")
     private List<ProductEntity> products;
 
     public CategoryEntity(CategoryRequest request) {
         this.name = request.name();
         this.description = request.description();
-        this.products =  mapProductRequestsToEntities(request.products());
+        this.products = mapProductRequestsToEntities(request.products());
     }
 
     public void updateInfo(CategoryRequest request) {
@@ -53,9 +52,7 @@ public class CategoryEntity {
 
     private List<ProductEntity> mapProductRequestsToEntities(List<ProductRequest> productRequests) {
         return productRequests.stream()
-                .map(ProductEntity::new) // Criar ProductEntity a partir do ProductRequest
+                .map(ProductEntity::new)
                 .collect(Collectors.toList());
     }
-
-    }
-
+}

--- a/src/main/java/com/stock/flex/entity/ProductEntity.java
+++ b/src/main/java/com/stock/flex/entity/ProductEntity.java
@@ -32,10 +32,9 @@ public class ProductEntity {
     private int displayOrder;
     private int starQuantity;
 
-
-    @ManyToOne // Estabelece o relacionamento muitos-para-um com a categoria
-    @JoinColumn(name = "category_id") // Especifique a coluna de junção
-    private CategoryEntity category; // Adicione esse atributo
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private CategoryEntity category;
 
 
     public ProductEntity(ProductRequest request) {
@@ -45,7 +44,6 @@ public class ProductEntity {
         this.quantity = request.quantity();
         this.displayOrder = request.displayOrder();
         this.starQuantity = request.starQuantity();
-
     }
 
     public void updateInfo(ProductRequest request) {

--- a/src/main/java/com/stock/flex/entity/ProductEntity.java
+++ b/src/main/java/com/stock/flex/entity/ProductEntity.java
@@ -1,6 +1,7 @@
 package com.stock.flex.entity;
 
 import com.stock.flex.resource.request.ProductRequest;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +31,12 @@ public class ProductEntity {
     private int quantity;
     private int displayOrder;
     private int starQuantity;
+
+
+    @ManyToOne // Estabelece o relacionamento muitos-para-um com a categoria
+    @JoinColumn(name = "category_id") // Especifique a coluna de junção
+    private CategoryEntity category; // Adicione esse atributo
+
 
     public ProductEntity(ProductRequest request) {
         this.name = request.name();

--- a/src/main/java/com/stock/flex/entity/StockEntity.java
+++ b/src/main/java/com/stock/flex/entity/StockEntity.java
@@ -1,6 +1,8 @@
 package com.stock.flex.entity;
 
+import com.stock.flex.resource.request.CategoryRequest;
 import com.stock.flex.resource.request.StockRequest;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.GenerationType;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -27,22 +30,33 @@ public class StockEntity {
     private UUID id;
     private String name;
     private String description;
-    private List<String> category;
+
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "stock")
+    private List<CategoryEntity> category;
 
     public StockEntity(StockRequest request) {
         this.name = request.name();
         this.description = request.description();
-        this.category = request.category();
+        this.category = mapCategoryRequestsToEntities(request.category());
     }
 
-    public void updateInfo(StockRequest response) {
-        if (response.name() != null) {
-            this.name = response.name();
+    public void updateInfo(StockRequest request) {
+        if (request.name() != null) {
+            this.name = request.name();
         }
-        if (response.description() != null) {
-            this.description = response.description();
+        if (request.description() != null) {
+            this.description = request.description();
         }
-        if (response.category() != null) {
-        this.category = response.category();}
+        if (request.category() != null) {
+        this.category = mapCategoryRequestsToEntities(request.category());
+        }
     }
+
+    private List<CategoryEntity> mapCategoryRequestsToEntities(List<CategoryRequest> categoryRequests) {
+        return categoryRequests.stream()
+                .map(CategoryEntity::new) // Criar CategoryEntity a partir do CategoryRequest
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/stock/flex/entity/StockEntity.java
+++ b/src/main/java/com/stock/flex/entity/StockEntity.java
@@ -55,7 +55,7 @@ public class StockEntity {
 
     private List<CategoryEntity> mapCategoryRequestsToEntities(List<CategoryRequest> categoryRequests) {
         return categoryRequests.stream()
-                .map(CategoryEntity::new) // Criar CategoryEntity a partir do CategoryRequest
+                .map(CategoryEntity::new)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/stock/flex/resource/CategoryResource.java
+++ b/src/main/java/com/stock/flex/resource/CategoryResource.java
@@ -45,7 +45,7 @@ public class CategoryResource {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity detalhar(@PathVariable UUID id) {
+    public ResponseEntity getById(@PathVariable UUID id) {
         var category = repository.getById(id);
         return ResponseEntity.ok(new CategoryResponse(category));
     }

--- a/src/main/java/com/stock/flex/resource/CategoryResource.java
+++ b/src/main/java/com/stock/flex/resource/CategoryResource.java
@@ -53,7 +53,7 @@ public class CategoryResource {
     @PutMapping("/{id}")
     @Transactional
     public ResponseEntity<CategoryRequest> updateCategory(@PathVariable UUID id, @RequestBody CategoryRequest request) {
-        var category = repository.getById(id);
+        var category = repository.getReferenceById(id);
         category.updateInfo(request);
         return ResponseEntity.ok(new CategoryRequest(category));
     }

--- a/src/main/java/com/stock/flex/resource/ProductResource.java
+++ b/src/main/java/com/stock/flex/resource/ProductResource.java
@@ -4,20 +4,12 @@ import com.stock.flex.entity.ProductEntity;
 import com.stock.flex.repository.ProductRepository;
 import com.stock.flex.resource.request.ProductRequest;
 import com.stock.flex.resource.response.ProductResponse;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 
-
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,9 +29,15 @@ public class ProductResource {
     }
 
     @GetMapping
-    public ResponseEntity<List<ProductResponse>> get() {// se fosse todos os dados
+    public ResponseEntity<List<ProductResponse>> get() {
         var product = repository.findAll().stream().map(ProductResponse::new).toList();
         return ResponseEntity.ok(product);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity getById(@PathVariable UUID id) {
+        var product = repository.getById(id);
+        return ResponseEntity.ok(new ProductResponse(product));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/stock/flex/resource/StockResource.java
+++ b/src/main/java/com/stock/flex/resource/StockResource.java
@@ -4,20 +4,12 @@ import com.stock.flex.entity.StockEntity;
 import com.stock.flex.repository.StockRepository;
 import com.stock.flex.resource.request.StockRequest;
 import com.stock.flex.resource.response.StockResponse;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 
-
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,6 +34,12 @@ public class StockResource {
         return ResponseEntity.ok(stock);
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity getById(@PathVariable UUID id) {
+        var stock = repository.getById(id);
+        return ResponseEntity.ok(new StockResponse(stock));
+    }
+
     @PutMapping("/{id}")
     @Transactional
     public ResponseEntity<StockResponse> update(@PathVariable UUID id, @RequestBody StockRequest request) {
@@ -49,7 +47,6 @@ public class StockResource {
         stock.updateInfo(request);
         return ResponseEntity.ok(new StockResponse(stock));
     }
-
 
     @DeleteMapping("/{id}")
     @Transactional

--- a/src/main/java/com/stock/flex/resource/request/CategoryRequest.java
+++ b/src/main/java/com/stock/flex/resource/request/CategoryRequest.java
@@ -16,7 +16,7 @@ public record CategoryRequest(String name,
 
     private static List<ProductRequest> mapProductsToRequests(List<ProductEntity> products) {
         return products.stream()
-                .map(ProductRequest::new) // Criar ProductRequest a partir de ProductEntity
+                .map(ProductRequest::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stock/flex/resource/request/CategoryRequest.java
+++ b/src/main/java/com/stock/flex/resource/request/CategoryRequest.java
@@ -1,14 +1,22 @@
 package com.stock.flex.resource.request;
 
 import com.stock.flex.entity.CategoryEntity;
+import com.stock.flex.entity.ProductEntity;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record CategoryRequest(String name,
                               String description,
-                              List<String> products) {
+                              List<ProductRequest> products) {
 
     public CategoryRequest(CategoryEntity category) {
-        this(category.getName(), category.getDescription(), category.getProducts());
+        this(category.getName(), category.getDescription(), mapProductsToRequests(category.getProducts()));
+    }
+
+    private static List<ProductRequest> mapProductsToRequests(List<ProductEntity> products) {
+        return products.stream()
+                .map(ProductRequest::new) // Criar ProductRequest a partir de ProductEntity
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stock/flex/resource/request/StockRequest.java
+++ b/src/main/java/com/stock/flex/resource/request/StockRequest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record StockRequest(String name,
                            String description,
-                           List<String> category) {
+                           List<CategoryRequest> category) {
 }
 
 

--- a/src/main/java/com/stock/flex/resource/response/CategoryResponse.java
+++ b/src/main/java/com/stock/flex/resource/response/CategoryResponse.java
@@ -18,7 +18,7 @@ public record CategoryResponse(UUID id,
 
     private static List<ProductResponse> mapProductsToResponses(List<ProductEntity> products) {
         return products.stream()
-                .map(ProductResponse::new) // Criar ProductResponse a partir de ProductEntity
+                .map(ProductResponse::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stock/flex/resource/response/CategoryResponse.java
+++ b/src/main/java/com/stock/flex/resource/response/CategoryResponse.java
@@ -1,16 +1,24 @@
 package com.stock.flex.resource.response;
 
 import com.stock.flex.entity.CategoryEntity;
+import com.stock.flex.entity.ProductEntity;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public record CategoryResponse(UUID id,
                                String name,
                                String description,
-                               List<String> products) {
+                               List<ProductResponse> products) {
 
     public CategoryResponse(CategoryEntity category) {
-        this(category.getId(), category.getName(), category.getDescription(), category.getProducts());
+        this(category.getId(), category.getName(), category.getDescription(), mapProductsToResponses(category.getProducts()));
+    }
+
+    private static List<ProductResponse> mapProductsToResponses(List<ProductEntity> products) {
+        return products.stream()
+                .map(ProductResponse::new) // Criar ProductResponse a partir de ProductEntity
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stock/flex/resource/response/StockResponse.java
+++ b/src/main/java/com/stock/flex/resource/response/StockResponse.java
@@ -1,16 +1,24 @@
 package com.stock.flex.resource.response;
 
+import com.stock.flex.entity.CategoryEntity;
 import com.stock.flex.entity.StockEntity;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public record StockResponse(UUID id,
                             String name,
                             String description,
-                            List<String>category) {
+                            List<CategoryResponse> categories) {
 
     public StockResponse(StockEntity stock) {
-        this(stock.getId(), stock.getName(), stock.getDescription(), stock.getCategory());
+        this(stock.getId(), stock.getName(), stock.getDescription(), mapCategoriesToResponses(stock.getCategory()));
+    }
+
+    private static List<CategoryResponse> mapCategoriesToResponses(List<CategoryEntity> categories) {
+        return categories.stream()
+                .map(CategoryResponse::new) // Criar CategoryResponse a partir de CategoryEntity
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stock/flex/resource/response/StockResponse.java
+++ b/src/main/java/com/stock/flex/resource/response/StockResponse.java
@@ -18,7 +18,7 @@ public record StockResponse(UUID id,
 
     private static List<CategoryResponse> mapCategoriesToResponses(List<CategoryEntity> categories) {
         return categories.stream()
-                .map(CategoryResponse::new) // Criar CategoryResponse a partir de CategoryEntity
+                .map(CategoryResponse::new)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Mapeamento de classes


1. **Atualização dos Tipos de Lista:** Atualizei os tipos de lista para refletirem as relações reais no projeto:
   - Agora, o tipo de lista usado em `StockRequest` é `CategoryEntity`.
   - Para `CategoryRequest`, o tipo de lista é `ProductEntity`.

2. **Refatoração dos Mapeamentos nas Entidades:** Os mapeamentos nas entidades foram ajustados para melhor representar as relações entre os objetos:
   - Um estoque (`StockEntity`) pode conter várias categorias (`CategoryEntity`).
   - Várias categorias podem estar associadas a um estoque.
   - Uma categoria pode conter múltiplos produtos (`ProductEntity`).
   - Muitos produtos podem pertencer a uma única categoria.

3. **Adição de Métodos de Mapeamento Preciso:** Novos métodos foram adicionados para realizar mapeamentos precisos entre solicitações e entidades, bem como entre entidades e respostas. Isso otimiza a manipulação de dados e garante consistência.


## Recursos Úteis


   - [Hibernate One-to-Many Relationship Tutorial](https://www.baeldung.com/hibernate-one-to-many)
   - [Java Maps and Streams Tutorial](https://www.baeldung.com/java-maps-streams)
